### PR TITLE
Add option for setting the nodePort

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -14,6 +14,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if (not (empty .Values.service.nodePort)) }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "springboot.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/values.yaml
+++ b/values.yaml
@@ -30,6 +30,7 @@ health:
 service:
   type: ClusterIP
   port: 80
+  # nodePort:
 
 ingress:
   enabled: true


### PR DESCRIPTION
See cloudogu/k8s-gitops-playground@9fde72a709fc43b982749b194fcc670c88ccb68d for an example.
E.g. this [file](https://github.com/cloudogu/k8s-gitops-playground/blob/9fde72a709fc43b982749b194fcc670c88ccb68d/applications/petclinic/fluxv1/helm/k8s/values-staging.yaml).