### PR TITLE
Sets ingress.enabled default to false

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -33,7 +33,7 @@ service:
   # nodePort:
 
 ingress:
-  enabled: true
+  enabled: false
   annotations: {}
   tls: []
 


### PR DESCRIPTION
If you need an Ingress you have to explicitly enable it

Signed-off-by: pmarkiewka <philipp.markiewka@cloudogu.com>