### PR TITLE
Migrate Ingress to Kubernetes v1.22

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
   {{- $fullName := include "springboot.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -31,9 +31,12 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
In v1.22 the API versions extensions/v1beta1 and networking.k8s.io/v1beta1 are no longer served.